### PR TITLE
Visual improvements

### DIFF
--- a/src/pypetb/RnR.py
+++ b/src/pypetb/RnR.py
@@ -1039,6 +1039,7 @@ class RnRNumeric:
                 df_0[df_0["Op"] == df_0["Op"].unique()[n]]["Valor"],
                 positions=[n + 1],
                 patch_artist=True,
+                medianprops=dict(color=mpl.colors.CSS4_COLORS["black"]),
                 boxprops=dict(facecolor=c, color=c),
             )
         ax4.set_ylabel("{}".format(self.__dict_key["3"]))

--- a/src/pypetb/RnR.py
+++ b/src/pypetb/RnR.py
@@ -857,6 +857,53 @@ class RnRNumeric:
             fontsize=20,
         )
 
+        number_of_technicians = len(df_0["Op"].unique())
+
+        technician_colors = [
+            mpl.colors.CSS4_COLORS["blue"],
+            mpl.colors.CSS4_COLORS["green"],
+            mpl.colors.CSS4_COLORS["orange"],
+            mpl.colors.CSS4_COLORS["purple"],
+            mpl.colors.CSS4_COLORS["maroon"],
+            mpl.colors.CSS4_COLORS["dodgerblue"],
+            mpl.colors.CSS4_COLORS["yellow"],
+        ]
+
+        technician_markers = [
+            "o",  # Circle
+            "8",  # Octagon
+            "s",  # Square
+            "p",  # Pentagon
+            "*",  # Star
+            "D",  # Diamond
+            "X",  # X Filled
+        ]
+
+        while len(technician_colors) < number_of_technicians:
+            generated_color = random.choice(
+                list(mpl.colors.CSS4_COLORS.values())
+            )
+
+            # Do not allow red as one of the technician colors as this is
+            # used for other purposes in the graphs. Also do not allow white
+            # as this will not be very visible
+            if (
+                generated_color is mpl.colors.CSS4_COLORS["red"]
+                or generated_color is mpl.colors.CSS4_COLORS["white"]
+            ):
+                continue
+
+            if generated_color is not generated_color not in technician_colors:
+                technician_colors.append(generated_color)
+
+        while len(technician_markers) < number_of_technicians:
+            generated_marker = random.choice(
+                list(mpl.lines.Line2D.markers.keys())
+            )
+
+            if generated_marker not in technician_markers:
+                technician_markers.append(generated_marker)
+
         # ============================================================================================
         #                                VARIACION
         # ============================================================================================
@@ -967,13 +1014,11 @@ class RnRNumeric:
             df_temp = df_1.xs(
                 df_0["Op"].unique()[i], level=0, drop_level=False
             )
-            c = random.choice(list(mpl.colors.CSS4_COLORS.values()))
-            m = random.choice(list(mpl.lines.Line2D.markers.keys()))
             lst_ax3[i].plot(
                 df_temp.index.get_level_values(1),
                 df_temp["Range"],
-                color=c,
-                marker=m,
+                color=technician_colors[i],
+                marker=technician_markers[i],
             )
             lst_ax3[i].set_xticks(df_temp.index.get_level_values(1))
 
@@ -989,7 +1034,7 @@ class RnRNumeric:
             fontweight="bold",
         )
         for n in range(0, len((df_0["Op"].unique()))):
-            c = random.choice(list(mpl.colors.CSS4_COLORS.values()))
+            c = technician_colors[n]
             ax4.boxplot(
                 df_0[df_0["Op"] == df_0["Op"].unique()[n]]["Valor"],
                 positions=[n + 1],
@@ -1034,13 +1079,12 @@ class RnRNumeric:
             df_temp = df_1.xs(
                 df_0["Op"].unique()[i], level=0, drop_level=False
             )
-            c = random.choice(list(mpl.colors.CSS4_COLORS.values()))
-            m = random.choice(list(mpl.lines.Line2D.markers.keys()))
+
             lst_ax5[i].plot(
                 df_temp.index.get_level_values(1),
                 df_temp["Mean"],
-                color=c,
-                marker=m,
+                color=technician_colors[i],
+                marker=technician_markers[i],
             )
             lst_ax5[i].set_xticks(df_temp.index.get_level_values(1))
 

--- a/src/pypetb/RnR.py
+++ b/src/pypetb/RnR.py
@@ -1048,8 +1048,8 @@ class RnRNumeric:
         #                                Xbarra per Operator
         # ============================================================================================
         lst_ax5 = list()
-        ax5_max = self.Total_max * 1.1
-        ax5_min = self.Total_min - self.Total_max * 0.1
+        ax5_max = self.Total_max * 1.001
+        ax5_min = self.Total_min - self.Total_max * 0.001
 
         for i in range(0, len(df_0["Op"].unique())):
             lst_ax5.append(Fig2.add_subplot(gs[2, i]))

--- a/src/pypetb/RnR.py
+++ b/src/pypetb/RnR.py
@@ -964,7 +964,7 @@ class RnRNumeric:
         ax1.set_title("Variation Component", fontweight="bold")
         ax1.set_xticks(X)
         ax1.set_xticklabels(x)
-        ax1.legend(loc="upper right", bbox_to_anchor=(1.4, 1))
+        ax1.legend(loc="upper left", bbox_to_anchor=(1, 1))
         ax1.set_ylim(0, 100)
 
         # ============================================================================================
@@ -1024,7 +1024,7 @@ class RnRNumeric:
 
         # lst_ax3[0].title.set_text('Range by {}'.format(dict_key['Op'])) #
         lst_ax3[1].set_xlabel("{}".format(self.__dict_key["2"]))  #
-        lst_ax3[-1].legend(loc="upper right", bbox_to_anchor=(2.1, 1))
+        lst_ax3[-1].legend(loc="upper left", bbox_to_anchor=(1, 1))
         # ============================================================================================
         #                                Violin Plot
         # ============================================================================================
@@ -1089,7 +1089,7 @@ class RnRNumeric:
             lst_ax5[i].set_xticks(df_temp.index.get_level_values(1))
 
         lst_ax5[1].set_xlabel("{}".format(self.__dict_key["2"]))  #
-        lst_ax5[-1].legend(loc="upper right", bbox_to_anchor=(2.1, 1))
+        lst_ax5[-1].legend(loc="upper left", bbox_to_anchor=(1, 1))
         # ============================================================================================
         #                                Iteration
         # ============================================================================================
@@ -1110,7 +1110,7 @@ class RnRNumeric:
             ax6.plot(
                 df_temp.index.get_level_values(1), df_temp["Mean"], label=item
             )
-        ax6.legend(loc="upper right", bbox_to_anchor=(1.5, 1))
+        ax6.legend(loc="upper left", bbox_to_anchor=(1, 1))
         ax6.set_xlabel("{}".format(self.__dict_key["2"]))
         ax6.set_ylabel("Mean")
         # ============================================================================================


### PR DESCRIPTION
- To increase visibility of the 'Sample Avg' graph the min & max values is changed from 10% above max/below min to 0.1%.
- To increase visibility of the median line of the boxplot, the color is set to black.
- Change graph legend placement so that they are left aligned with each other.
- Replace randomized colors and markers for technicians with static ones, to have consistent looking graphs between runs and multiple measurements.

Fixes: #43 